### PR TITLE
Update input_data.html - dropping non-biallelic SNPs in ConvertFromVcf

### DIFF
--- a/docs/input_data.html
+++ b/docs/input_data.html
@@ -251,7 +251,7 @@ gtag('config', 'UA-115753061-1');
                 <div class="panel-heading"> <h4 id="ConvertFromVcf">Convert from vcf</h4></div>
                 <div class="panel-body">  
 
-                  Converts from the vcf file format to the haps/sample file format.
+                  Converts from the vcf file format to the haps/sample file format. During the process non-biallelic SNPs are dropped.
 
                   <dl class="dl-horizontal">
                     <dt>--haps</dt>


### PR DESCRIPTION
It seems that `ConvertFromVcf` mode drops non-biallelic SNPs - hence this suggested edit. Happy to provide an example if needed.

