### PR TITLE
PrepareInputFiles bugfix, add "EstimatePopulationSize.sh --noplot"

### DIFF
--- a/docs/modules.html
+++ b/docs/modules.html
@@ -199,6 +199,8 @@ gtag('config', 'UA-115753061-1');
                     <dd>Optional: Float in [0,1] which is the fraction of trees to be dropped, ranked by number of mutations mapping. This option serves two purposes: First, it removes bad/uninformative trees. Second it speeds up the inference. As we increase this value, we remove more trees. Default: 0.5.</dd>
                     <dt>--seed</dt>
                     <dd>Optional: Seed for the random number generator used in the MCMC algorithm for estimating branch lengths.</dd>
+                    <dt>--noplot</dt>
+                    <dd>Optional: Takes no value. If specified, do not plot the results using R.</dd>
 
                   </dl>
 

--- a/scripts/EstimatePopulationSize/EstimatePopulationSize.sh
+++ b/scripts/EstimatePopulationSize/EstimatePopulationSize.sh
@@ -27,6 +27,7 @@ then
   echo "--norm_mutrate     Optional: Normalise coal rates by mutation rate. Recommended if SNPs are MAF ascertained."
   echo "--threads:         Optional. Maximum number of threads."
   echo "--seed:            Optional: Random seed for branch lengths estimation"
+  echo "--noplot:          Optional: Do not run R script to plot results"
   echo ""
   exit 1;
 fi
@@ -131,6 +132,10 @@ do
       seed="$2"
       shift # past argument
       shift # past value
+      ;;
+    --noplot)
+      noplot=1
+      shift # past argument
       ;;
 
     *)    # unknown option
@@ -1340,7 +1345,8 @@ then
   rm ${output}_${labels}*
 fi
 
-#plot results
-Rscript ${DIR}/plot_population_size.R ${output} ${years_per_gen}
-
-
+if [ -z ${noplot-} ];
+then
+  #plot results
+  Rscript ${DIR}/plot_population_size.R ${output} ${years_per_gen}
+fi

--- a/scripts/PrepareInputFiles/PrepareInputFiles.sh
+++ b/scripts/PrepareInputFiles/PrepareInputFiles.sh
@@ -210,5 +210,7 @@ fi
 
 gzip ${filename_output}.haps
 gzip ${filename_output}.sample
-gzip ${filename_output}.dist
+if [ -f ${filename_output}.dist ]; then
+    gzip ${filename_output}.dist
+fi
 


### PR DESCRIPTION
Two small bash script changes.

* `PrepareInputFiles.sh` only emits a .dist file if the --mask option is provided, but the script was assuming a .dist file was always created.
* Add "--noplot" option to `EstimatePopulationSize.sh` which prevents the running of the R script to plot the results. Helpful for folks who are scripting their Relate runs, but don't have the necessary R modules on their compute node(s).